### PR TITLE
Incorrect Time Format in pojo.mustache for DateTime Pattern

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/pojo.mustache
@@ -46,7 +46,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
 {{/isDate}}
 {{#isDateTime}}
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'hh:mm:ss.SSSX")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
 {{/isDateTime}}
 {{#vendorExtensions.x-field-extra-annotation}}
 {{{vendorExtensions.x-field-extra-annotation}}}


### PR DESCRIPTION
The pattern uses hh for the hour, which refers to a 12-hour clock format (requiring AM/PM context). However, this context is not present in the pattern. If the goal is to format the time in 24-hour clock, the correct placeholder should be HH.
